### PR TITLE
pc - add autograder zips to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Autograders
+autograder.zip
 examples/gradescope/zips/*.zip
 
 # Mac Stuff

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Autograders
+examples/gradescope/zips/*.zip
+
 # Mac Stuff
 .DS_Store
 


### PR DESCRIPTION
In this PR, we update the .gitignore so that the .zip files for generated autograders don't get committed to the repo.