### PR TITLE
Explicitly mark failed 0-point tests as failed

### DIFF
--- a/src/main/java/com/github/dscpsyl/jgrade2/gradescope/GradescopeJsonFormatter.java
+++ b/src/main/java/com/github/dscpsyl/jgrade2/gradescope/GradescopeJsonFormatter.java
@@ -31,6 +31,8 @@ public class GradescopeJsonFormatter implements OutputFormatter {
     private static final String NUMBER = "number";
     private static final String OUTPUT = "output";
     private static final String VISIBILITY = "visibility";
+    private static final String STATUS = "status";
+    private static final String FAILED = "failed";
 
     private JSONObject json;
     private int prettyPrint;
@@ -126,13 +128,17 @@ public class GradescopeJsonFormatter implements OutputFormatter {
      */
     private JSONObject assemble(GradedTestResult r) {
         try {
-            return new JSONObject()
+            JSONObject rval =  new JSONObject()
                     .put(NAME, r.getName())
                     .put(SCORE, r.getScore())
                     .put(MAX_SCORE, r.getPoints())
                     .put(NUMBER, r.getNumber())
                     .put(OUTPUT, r.getOutput())
                     .put(VISIBILITY, r.getVisibility());
+            if (!r.passed()) {
+                rval.put(STATUS, FAILED);
+            }
+            return rval;
         } catch (JSONException e) {
             throw new InternalError(e);
         }


### PR DESCRIPTION
## Overview
Updates the GradescopeJsonFormatter to explicitly flag failed tests as failed. This mainly matters when tests are worth 0 points - if `status` is not specified in the JSON, then Gradescope assumes that a test that earned max points has passed. So, when a test is worth 0 points, it shows as passed even if it fails or aborts. This change explicitly includes the `status` field in the JSON if a test has been marked as failing.

See the Test Case Status section in the Gradescope specifications: https://gradescope-autograders.readthedocs.io/en/latest/specs/ for more detail.

## Tests
- [ ] Unit tests (`mvn test`) 100%
- [ ] Mutation tests (`mvn test pitest:mutationCoverage`) 80%
- [ ] Test coverage (`mvn test jacoco:report`) 75%/50%
- [ ] Checkstyle (`mvn test checkstyle:checkstyle`) 0 errors
- [ ] Package version in `pom.xml` match that in `jGrade2.java`
- [ ] Java version match in `pom.xml`, `.github/workflows/Javadoc-deploy.yml` and `res/.java-version`
- [ ] `CHANGELOG.md` is up to date
- [ ] git `HEAD` is labeled with a version tag
