### PR TITLE
docs:Update readme on the jreleaser env variables

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -18,8 +18,8 @@ jobs:
           java-version-file: ./res/.java-version
       - name: Publish package
         env:
-          JRELEASER_NEXUS2_USERNAME: ${{ secrets.JRELEASER_NEXUS2_USERNAME }}
-          JRELEASER_NEXUS2_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_PASSWORD }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_TOKEN }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}

--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           distribution: temurin
           java-version-file: ./res/.java-version
+      - name: Check JRelease Configs
+        run: ./nvmw -Prelease jreleaser:config
       - name: Publish package
         env:
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@
 _These new formats are from >2.0.0 (alpha-1)_
 
 
-### v2.0.0
+### v2.0.0-a3
 
-#### Added
-
-- Install via Maven Central
+#### Changed
+- Project organization is now `com.github.jgrade2` to match the new Github organization
+- Updated Maven Central release workflow to match the new Central Repository requirements vs the old OSSRH repository.
+- Updated README to reflect the new project location and organization.
 
 ### v2.0.0-a2
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,6 @@ There are also a few notes in the `pom.xml` file that you should take note of.
 - `<developers>`: You can update the developers section to include yourself but no change is necessary. Just make sure it is reasonable.
 - `<groupId>`: This should be updated to match the *namespace* of your Sonatype account.
 - `<version>`: Update this to match the `CHANGELOG.md` file as well as the git tag of the release.
-- `<project.finalName>`: This should be updated to match the name and version of the jar file you want to publish. This is the name of the jar file that will be published to Maven Central.
 - `<java.target.version>`: This should be updated to match the version of Java you are using. This is used for the JavaDoc generation and many other items.
 - `<jreleaser.*>`: Any tags starting with `jreleaser` are configs that can be configured if needed.
 

--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ This workflow runs whenever a tag commit is pushed onto the `main` branch. It wi
 
 This workflow will run whenever a release is published on Github. It uitilizes [jReleaser](https://github.com/jreleaser/jreleaser) to deploy to Maven Central. There are a few secrets that need to be present in the repo for this to work. 
 
-- `JRELEASER_NEXUS2_USERNAME`: The variable name is legacy but it will work the same. This is the username of your [Sonatype](https://central.sonatype.com/) account.
-- `JRELEASER_NEXUS2_PASSWORD`: The variable name is legacy but it will work the same. The password of your [Sonatype](https://central.sonatype.com/) account.
-- `RELEASER_GPG_PASSPHRASE`: The passphrase of your GPG key. This is used to sign the release.
+- `JRELEASER_MAVENCENTRAL_USERNAME`: The username of your [Sonatype](https://central.sonatype.com/) account.
+- `JRELEASER_MAVENCENTRAL_TOKEN`: This is the User Token associated with the account in `JRELEASER_MAVENCENTRAL_USERNAME`.
+- `JRELEASER_GPG_PASSPHRASE`: The passphrase of your GPG key. This is used to sign the release.
 - `JRELEASER_GPG_SECRET_KEY`: The secret key of your GPG key. This is used to sign the release.
 - `JRELEASER_GPG_PUBLIC_KEY`: The public key of your GPG key. This is used to sign the release.
   

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-This is an update to the original jGrade, now supporting Java17 and [JUnit5](https://junit.org/junit5/). This provides four 
+This is an update to the original jGrade, now supporting Java21 and [JUnit5](https://junit.org/junit5/). This provides four 
 annotations: `@Grade` (+ `@BeforeGrading` and `@AfterGrading`) and `@GradedTest`, each meant to help autograde 
 student assignments in Java for the Gradescope autograder. When correctly setup, instructors can 
 simply use JUnit5 to write tests for assignemnts. This library will automatically capture results, 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <groupId>io.github.jgrade2</groupId>
     <artifactId>jgrade2</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0-a2</version> <!-- NOTE - If major/minor version changes, update project.finalName in properties -->
+    <version>2.0.0-a3</version>
 
     <name>jgrade2</name>
     <inceptionYear>2023</inceptionYear>
@@ -58,7 +58,7 @@
     </licenses>
 
     <properties> <!-- NOTE - All dependency, java, and plugin versions should be added/changed here -->
-        <project.finalName>jgrade2-2.0.0-a2</project.finalName>
+        <project.finalName>{$artifactId}-{$version}</project.finalName>
         <java.target.version>21</java.target.version>
 
         <commons-cli.version>1.5.0</commons-cli.version>
@@ -78,7 +78,7 @@
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 
         <!-- Maven Central release options-->
-        <jreleaser.version>1.9.0</jreleaser.version>
+        <jreleaser.version>1.17.0</jreleaser.version>
         <jreleaser.closeRepository>true</jreleaser.closeRepository>
         <jreleaser.releaseRepository>true</jreleaser.releaseRepository>
         <target.deploy.folder>local::file:./target/staging-deploy</target.deploy.folder>
@@ -436,23 +436,21 @@
                         <version>${jreleaser.version}</version>
                         <configuration>
                             <jreleaser>
-                            <signing>
-                                <active>ALWAYS</active>
-                                <armored>true</armored>
-                            </signing>
-                            <deploy>
-                                <maven>
-                                <nexus2>
-                                    <maven-central>
+                                <signing>
                                     <active>ALWAYS</active>
-                                    <url>https://s01.oss.sonatype.org/service/local</url>;
-                                    <closeRepository>${jreleaser.closeRepository}</closeRepository>
-                                    <releaseRepository>${jreleaser.releaseRepository}</releaseRepository>
-                                    <stagingRepositories>target/staging-deploy</stagingRepositories>
-                                    </maven-central>
-                                </nexus2>
-                                </maven>
-                            </deploy>
+                                    <armored>true</armored>
+                                </signing>
+                                <deploy>
+                                    <maven>
+                                        <mavenCentral>
+                                            <sonatype>
+                                                <active>ALWAYS</active>
+                                                <url>https://central.sonatype.com/api/v1/publisher</url>
+                                                <stagingRepositories>target/staging-deploy</stagingRepositories>
+                                            </sonatype>
+                                        </mavenCentral>
+                                    </maven>
+                                </deploy>
                             </jreleaser>
                         </configuration>
                     </plugin>

--- a/src/main/java/com/github/jgrade2/jgrade2/JGrade2.java
+++ b/src/main/java/com/github/jgrade2/jgrade2/JGrade2.java
@@ -44,7 +44,7 @@ import java.net.MalformedURLException;
  */
 public final class JGrade2 {
 
-    private static final String VERSION = "2.0.0-a2";
+    private static final String VERSION = "2.0.0-a3";
 
     private static final String CLASS_OPT = "classname";
     private static final String HELP_OPT = "help";


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, the release method is updated from Maven OSSRH to Maven Central Portal. The minor version number is also incremented to `2.0.0-a3` to denote it as the most recent version. However, its functionality is no different than `2.0.0-a2`.

## Tests
<!--Add any additional tests or required tests-->
- [x] Package version in `pom.xml` match that in `jGrade2.java`
- [x] Java version match in `pom.xml`, `.github/workflows/Javadoc-deploy.yml` and `res/.java-version`
- [x] `CHANGELOG.md` is up to date

## Linked Issues
<!--Issues related to the PR-->
Closes #9 
