### PR TITLE
Update to version v2.0.0-a4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@
 _These new formats are from >2.0.0 (alpha-1)_
 
 
-### v2.0.0-a3
+### v2.0.0-a4
 
 #### Fixed
 - Deadlock in `CLITester` when executing processes with large output (e.g. Checkstyle).
 - Various spelling and grammatical errors in `README.md`
+
+### v2.0.0-a3
 
 #### Changed
 - Project organization is now `com.github.jgrade2` to match the new Github organization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ _These new formats are from >2.0.0 (alpha-1)_
 
 ### v2.0.0-a3
 
+#### Fixed
+- Deadlock in `CLITester` when executing processes with large output (e.g. Checkstyle).
+- Various spelling and grammatical errors in `README.md`
+
 #### Changed
 - Project organization is now `com.github.jgrade2` to match the new Github organization
 - Updated Maven Central release workflow to match the new Central Repository requirements vs the old OSSRH repository.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 This is an update to the original jGrade, now supporting Java21 and [JUnit5](https://junit.org/junit5/). This provides four 
 annotations: `@Grade` (+ `@BeforeGrading` and `@AfterGrading`) and `@GradedTest`, each meant to help autograde 
 student assignments in Java for the Gradescope autograder. When correctly setup, instructors can 
-simply use JUnit5 to write tests for assignemnts. This library will automatically capture results, 
+simply use JUnit5 to write tests for assignments. This library will automatically capture results, 
 and output the correct json format for Gradescope to read.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -78,16 +78,16 @@ There are two ways to install jGrade2.
 
 ## Usage
 
-Usage is nearly identical to the origional [jGrade](https://github.com/tkutcher/jgrade). jGrade2 comes with a commandline
+Usage is nearly identical to the original [jGrade](https://github.com/tkutcher/jgrade). jGrade2 comes with a command line
 to run the grader manually. This is useful for debugging and testing. After compiling, you can use
 
 ```java -jar jGrade2.jar -h```
 
-for help and options of the commandline. However, a typical usage would be
+for help and options of the command line. However, a typical usage would be
 
 ```java -jar jGrade2.jar -c ExampleGrading -o results.json```
 
-### Test Writting and Grading
+### Test Writing and Grading
 
 You can take a look at the gradescope example in `examples/gradescope` for a full example.
 
@@ -127,7 +127,7 @@ public class ExampleTest {
 ```
 
 The `@GradedTest` annotation has the following parameters:
-- `name` - The name of the test. This will be displayed in the Gradescope interface. DEFAUT: "Unnamed test"
+- `name` - The name of the test. This will be displayed in the Gradescope interface. DEFAULT: "Unnamed test"
 - `number` - The test number in a string. This will be displayed in the Gradescope interface. DEFAULT: ""
 - `points` - The number of points this test is worth. DEFAULT: 1.0
 - `visibility` - The visibility of the test. This can be either VISIBLE or HIDDEN. DEFAULT: VISIBLE
@@ -199,7 +199,7 @@ The `lib/` folder contains all jars and library files needed to run your test - 
 
  `test_submissions/` are submissions to test with on Gradescope. These are precompiled for you to test with the grader that is included in the example.
 
- The source has 2 main packages, `staff` and `student`. The staff package contains the unit tests, a solution (to debug with) and the code to do the grading. The student package contains studnet skeleton code for studnets to fill in.
+ The source has 2 main packages, `staff` and `student`. The staff package contains the unit tests, a solution (to debug with) and the code to do the grading. The student package contains student skeleton code for students to fill in.
 
  While debugging, a makefile is provided for compiling and running. `make output` will start fresh and run the autograder, pretty-printing the output to the console.
 
@@ -237,9 +237,9 @@ Contributions are what make the open source community such an amazing place to l
 
 The repository is structured like so:
 - `main & master` The main branches for publishing to maven central. These should be kept clean and only update with releases. It is also protected and can only be added to via a pull request.
-- `dev` The development branch. This is where all development should be done and contains pe-releases. It is protected and can only be added to via a pull request.
+- `dev` The development branch. This is where all development should be done and contains pre-releases. It is protected and can only be added to via a pull request.
 
-Other branches are for personal developnment and should only be pulled to the `dev` branch. Once a release is determined, then a pull request can be made to `main` or `master`.
+Other branches are for personal development and should only be pulled to the `dev` branch. Once a release is determined, then a pull request can be made to `main` or `master`.
 
 If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
 Don't forget to give the project a star! Thanks again!
@@ -262,18 +262,18 @@ This workflow will run when a pull request is opened and when a push is made to 
 
 #### JavaDoc
 
-This workflow runs whenever a push is made to the `main` branch. It will build the javadoc and push it to the `javadoc` branch. This will update the javadoc on the [github pages](https://jgrade2.github.io/jgrade2/javadoc/). It uitilizes the native javadoc extension.
+This workflow runs whenever a push is made to the `main` branch. It will build the javadoc and push it to the `javadoc` branch. This will update the javadoc on the [github pages](https://jgrade2.github.io/jgrade2/javadoc/). It utilizes the native javadoc extension.
 
 #### Github Release
 
 This workflow runs whenever a tag commit is pushed onto the `main` branch. It will create and publish a new release based on the compiled jar file. This is based on the `gh_release` profile in `pom.xml`. Please see the `pom.xml` file for more information.
 
-*A note on this specific workflow:* There is no currently known way of easily getting both the ref tag and the ref branch name in a single workflow from the Github context. Depending on how the worflow is triggered, either the tag or the branch name will be used. Thus, the way branch and tag information is checked could break or be irrevelant at any time.
+*A note on this specific workflow:* There is no currently known way of easily getting both the ref tag and the ref branch name in a single workflow from the Github context. Depending on how the workflow is triggered, either the tag or the branch name will be used. Thus, the way branch and tag information is checked could break or be irrelevant at any time.
 
 
 #### Maven Release
 
-This workflow will run whenever a release is published on Github. It uitilizes [jReleaser](https://github.com/jreleaser/jreleaser) to deploy to Maven Central. There are a few secrets that need to be present in the repo for this to work. 
+This workflow will run whenever a release is published on Github. It utilizes [jReleaser](https://github.com/jreleaser/jreleaser) to deploy to Maven Central. There are a few secrets that need to be present in the repo for this to work. 
 
 - `JRELEASER_MAVENCENTRAL_USERNAME`: The username of your [Sonatype](https://central.sonatype.com/) account.
 - `JRELEASER_MAVENCENTRAL_TOKEN`: This is the User Token associated with the account in `JRELEASER_MAVENCENTRAL_USERNAME`.
@@ -304,7 +304,7 @@ Distributed under the MIT License. See `LICENSE.txt` for more information.
 
 * This is an update of the original [jGrade](https://github.com/tkutcher/jgrade).
 * Originally developed by [dscpsyl](https://github.com/dscpsyl) and directed by [pconrad](https://github.com/pconrad)
-  * Origional fork here: [dscpsyl/jGrade2](https://github.com/dscpsyl/jgrade2)
+  * Original fork here: [dscpsyl/jGrade2](https://github.com/dscpsyl/jgrade2)
 * Currently maintained by the CMPSC 192 course staff and students at University of California, Santa Barbara
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <groupId>io.github.jgrade2</groupId>
     <artifactId>jgrade2</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0-a3</version>
+    <version>2.0.0-a4</version>
 
     <name>jgrade2</name>
     <inceptionYear>2023</inceptionYear>

--- a/src/main/java/com/github/jgrade2/jgrade2/CLITester.java
+++ b/src/main/java/com/github/jgrade2/jgrade2/CLITester.java
@@ -5,11 +5,13 @@ import org.junit.jupiter.api.BeforeEach;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 
 /**
@@ -209,25 +211,36 @@ public abstract class CLITester {
                                            String toWriteIn) {
         try {
             Process proc = builder.start();
-            OutputStream driverStdin = proc.getOutputStream();
-            InputStream driverStdout = proc.getInputStream();
-            InputStream driverStderr = proc.getErrorStream();
 
-            // FIXME - Is there a fancier way to do this?
+            CompletableFuture<String> stdoutFuture = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return getStringFromStream(proc.getInputStream());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            CompletableFuture<String> stderrFuture = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return getStringFromStream(proc.getErrorStream());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
             if (toWriteIn != null) {
-                BufferedWriter writer = new BufferedWriter(
-                        new OutputStreamWriter(driverStdin));
-                writer.write(toWriteIn);
-                writer.flush();
-                writer.close();
+                try (BufferedWriter writer = new BufferedWriter(
+                        new OutputStreamWriter(proc.getOutputStream()))) {
+                    writer.write(toWriteIn);
+                    writer.flush();
+                }
             }
 
             int exitValue = proc.waitFor();
 
-            return new ExecutionResult(getStringFromStream(driverStdout),
-                    getStringFromStream(driverStderr), exitValue);
+            return new ExecutionResult(stdoutFuture.get(), stderrFuture.get(), exitValue);
 
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException | InterruptedException | ExecutionException e) {
             throw new InternalError(e);
         }
     }
@@ -250,8 +263,6 @@ public abstract class CLITester {
      * @throws IOException If there is an error reading from the stream.
      */
     private static String getStringFromStream(InputStream stream) throws IOException {
-        byte[] streamBytes = new byte[stream.available()];
-        stream.read(streamBytes, 0, streamBytes.length);
-        return new String(streamBytes);
+        return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/com/github/jgrade2/jgrade2/CLITesterDeadlockTest.java
+++ b/src/test/java/com/github/jgrade2/jgrade2/CLITesterDeadlockTest.java
@@ -1,0 +1,18 @@
+package com.github.jgrade2.jgrade2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class CLITesterDeadlockTest {
+
+    @Test
+    @org.junit.jupiter.api.Timeout(10) // 10 seconds timeout
+    public void testLargeOutputDoesNotDeadlock() {
+        // This command produces a lot of output to stdout.
+        // On most systems, 100,000 lines should be enough to fill the buffer.
+        ProcessBuilder pb = new ProcessBuilder("seq", "100000");
+        CLIResult result = CLITester.executeProcess(pb);
+        assertFalse(result.getOutput().isEmpty());
+    }
+}


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we merge and deploy the CLITester bug fix, bumping the version to v2.0.0-a4

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
<!--Add any additional tests or required tests-->
- [x] Unit tests (`mvn test`) 100%
- [x] Mutation tests (`mvn test pitest:mutationCoverage`) 80%
- [x] Test coverage (`mvn test jacoco:report`) 75%/50%
- [x] Checkstyle (`mvn test checkstyle:checkstyle`) 0 errors
- [x] Package version in `pom.xml` match that in `jGrade2.java`
- [x] Java version match in `pom.xml`, `.github/workflows/Javadoc-deploy.yml` and `res/.java-version`
- [x] `CHANGELOG.md` is up to date
- [x] git `HEAD` is labeled with a version tag

## Linked Issues
<!--Issues related to the PR-->
Closes #0
