### PR TITLE
Write Perms For Release Workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -10,7 +10,9 @@ jobs:
   upload-release:
     name: Build and Upload Release
     runs-on: ubuntu-latest
-    if: contains(${{ github.event.base_ref }}, 'main')
+    permissions:
+      contents: write
+    if: contains(github.event.base_ref, 'main')
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3.5.2


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add explicit write permissions to the github release action since it now defaults to read-only
Additionally, fixed a minor syntax error that caused the `if` clause to always return true.

## Tests
<!--Add any additional tests or required tests-->
- [ ] Unit tests (`mvn test`) 100%
- [ ] Mutation tests (`mvn test pitest:mutationCoverage`) 80%
- [ ] Test coverage (`mvn test jacoco:report`) 75%/50%
- [ ] Checkstyle (`mvn test checkstyle:checkstyle`) 0 errors
- [ ] Package version in `pom.xml` match that in `jGrade2.java`
- [ ] Java version match in `pom.xml`, `.github/workflows/Javadoc-deploy.yml` and `res/.java-version`
- [ ] `CHANGELOG.md` is up to date
- [ ] git `HEAD` is labeled with a version tag

## Linked Issues
<!--Issues related to the PR-->
Closes #0
